### PR TITLE
[Ready for Review] Refining setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -50,11 +50,11 @@ if [[ ${OSTYPE} == 'linux'* ]] ; then
     fi
     echo "--> Checking system packages and installing any missing packages"
     YUMPACKAGES=" \
+      jq \
       curl \
       python \
       tar \
       which \
-      jq \
       openssl \
       "
     for package in $YUMPACKAGES ; do
@@ -142,6 +142,8 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
 ## Mystery linux system without any of our recognised package managers
   else
     command -v curl >/dev/null 2>&1 || { echo >&2 "curl not found; please install and re-run this script."; exit 1; }
+    command -v awk >/dev/null 2>&1 || { echo >&2 "awk not found; please install and re-run this script."; exit 1; }
+    command -v grep >/dev/null 2>&1 || { echo >&2 "grep not found; please install and re-run this script."; exit 1; }
     command -v python >/dev/null 2>&1 || { echo >&2 "python not found; please install and re-run this script."; exit 1; }
     command -v jq >/dev/null 2>&1 || { echo >&2 "jq not found; please install and re-run this script."; exit 1; }
     echo "--> Attempting to install Azure-CLI with curl"
@@ -159,6 +161,8 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
 ## Helm isn't well packaged for Linux, alas
   if ! command -v helm >/dev/null 2>&1 ; then
     command -v curl >/dev/null 2>&1 || { echo >&2 "curl not found; please install and re-run this script."; exit 1; }
+    command -v awk >/dev/null 2>&1 || { echo >&2 "awk not found; please install and re-run this script."; exit 1; }
+    command -v grep >/dev/null 2>&1 || { echo >&2 "grep not found; please install and re-run this script."; exit 1; }
     command -v python >/dev/null 2>&1 || { echo >&2 "python not found; please install and re-run this script."; exit 1; }
     command -v tar >/dev/null 2>&1 || { echo >&2 "tar not found; please install and re-run this script."; exit 1; }
     command -v which >/dev/null 2>&1 || { echo >&2 "which not found; please install and re-run this script."; exit 1; }

--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,9 @@ if [[ ${OSTYPE} == 'linux'* ]] ; then
       curl \
       python \
       tar \
+      which \
       jq \
+      openssl \
       "
     for package in $YUMPACKAGES ; do
       if ! rpm -q $package > /dev/null ; then

--- a/setup.sh
+++ b/setup.sh
@@ -36,6 +36,18 @@ if [[ ${OSTYPE} == 'linux'* ]] ; then
 
 ## yum-based systems
   elif command -v yum >/dev/null 2>&1 ; then
+    if [ "$(cat /etc/redhat-release | grep -i centos)" ] ; then
+      echo "***************************************************************"
+      echo "* You appear to be running CentOS. A required package, jq, is *"
+      echo "* not available from core repositories but can be installed   *"
+      echo "* from the epel-release repository. If a jq install fails,    *"
+      echo "* run the following command as root (or with sudo) to enable  *"
+      echo "* the epel repository:                                        *"
+      echo "*                                                             *"
+      echo "*                  yum -y install epel-release                *"
+      echo "*                                                             *"
+      echo "***************************************************************"
+    fi
     echo "--> Checking system packages and installing any missing packages"
     YUMPACKAGES=" \
       curl \

--- a/setup.sh
+++ b/setup.sh
@@ -12,8 +12,7 @@ if [[ ${OSTYPE} == 'linux'* ]] ; then
     # Update apt before starting, in case this is a new container
     APTPACKAGES=" \
       curl \
-      # python \
-      # python3 \
+      python \
       openssl \
       jq \
       "
@@ -40,11 +39,9 @@ if [[ ${OSTYPE} == 'linux'* ]] ; then
     echo "--> Checking system packages and installing any missing packages"
     YUMPACKAGES=" \
       curl \
-      # python \
+      python \
       tar \
-	which \
       jq \
-	openssl \
       "
     for package in $YUMPACKAGES ; do
       if ! rpm -q $package > /dev/null ; then
@@ -52,14 +49,6 @@ if [[ ${OSTYPE} == 'linux'* ]] ; then
         ${sudo_command} yum install -y $package
 	fi
     done
-    # if ! command -v python3 >/dev/null 2>&1 ; then
-    #   if [ -f /etc/fedora-release ] ; then
-    #     ${sudo_command} yum install -y python3 python3-pyyaml
-    #   else
-    #     ${sudo_command} yum install -y epel-release
-    #     ${sudo_command} yum install -y python36 python36-PyYAML
-    #   fi
-    # fi
     if ! command -v az >/dev/null 2>&1 ; then
       echo "--> Attempting to install Azure-CLI with yum packages"
       ${sudo_command} rpm --import https://packages.microsoft.com/keys/microsoft.asc
@@ -84,12 +73,11 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
     echo "--> Checking system packages and installing any missing packages"
     ZYPPERPACKAGES=" \
       curl \
-      # python \
-      # python3 \
+      python \
       tar \
       which \
       jq \
-	openssl \
+      openssl \
       "
     for package in $ZYPPERPACKAGES ; do
       if ! rpm -q $package > /dev/null ; then
@@ -103,7 +91,7 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
       ${sudo_command} zypper addrepo --name 'Azure CLI' --check https://packages.microsoft.com/yumrepos/azure-cli azure-cli
       ${sudo_command} zypper install --from azure-cli -y azure-cli
       # The az-cli installer misses python-xml dependency on suse
-      # ${sudo_command} zypper install -y python-xml
+      ${sudo_command} zypper install -y python-xml
     fi
     if ! command -v kubectl >/dev/null 2>&1 ; then
       echo "--> Attempting to install kubectl with zypper packages"
@@ -114,7 +102,7 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
 ## Mystery linux system without any of our recognised package managers
   else
     command -v curl >/dev/null 2>&1 || { echo >&2 "curl not found; please install and re-run this script."; exit 1; }
-    # command -v python >/dev/null 2>&1 || { echo >&2 "python not found; please install and re-run this script."; exit 1; }
+    command -v python >/dev/null 2>&1 || { echo >&2 "python not found; please install and re-run this script."; exit 1; }
     command -v jq >/dev/null 2>&1 || { echo >&2 "jq not found; please install and re-run this script."; exit 1; }
     echo "--> Attempting to install Azure-CLI with curl"
     if ! command -v az >/dev/null 2>&1 ; then
@@ -131,7 +119,7 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
 ## Helm isn't well packaged for Linux, alas
   if ! command -v helm >/dev/null 2>&1 ; then
     command -v curl >/dev/null 2>&1 || { echo >&2 "curl not found; please install and re-run this script."; exit 1; }
-    # command -v python >/dev/null 2>&1 || { echo >&2 "python not found; please install and re-run this script."; exit 1; }
+    command -v python >/dev/null 2>&1 || { echo >&2 "python not found; please install and re-run this script."; exit 1; }
     command -v tar >/dev/null 2>&1 || { echo >&2 "tar not found; please install and re-run this script."; exit 1; }
     command -v which >/dev/null 2>&1 || { echo >&2 "which not found; please install and re-run this script."; exit 1; }
     echo "--> Helm doesn't have a system package; attempting to install with curl"
@@ -146,7 +134,7 @@ elif [[ ${OSTYPE} == 'darwin'* ]] ; then
     echo "--> Checking brew packages and installing any missing packages"
     BREWPACKAGES=" \
       curl \
-      # python \
+      python \
       azure-cli \
       kubernetes-cli \
       kubernetes-helm \
@@ -160,7 +148,7 @@ elif [[ ${OSTYPE} == 'darwin'* ]] ; then
     done
   else
     command -v curl >/dev/null 2>&1 || { echo >&2 "curl not found; please install and re-run this script."; exit 1; }
-    # command -v python >/dev/null 2>&1 || { echo >&2 "python not found; please install and re-run this script."; exit 1; }
+    command -v python >/dev/null 2>&1 || { echo >&2 "python not found; please install and re-run this script."; exit 1; }
     command -v tar >/dev/null 2>&1 || { echo >&2 "tar not found; please install and re-run this script."; exit 1; }
     command -v which >/dev/null 2>&1 || { echo >&2 "which not found; please install and re-run this script."; exit 1; }
     echo "--> Attempting to install Azure-CLI with curl"

--- a/setup.sh
+++ b/setup.sh
@@ -101,6 +101,32 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
       zypper install -y kubectl
     fi
 
+## pacman-based systems
+  elif command -v pacman >/dev/null 2>&1 ; then
+    echo "--> Checking system packages and installing any missing packages"
+    PACMANPACKAGES=" \
+      curl \
+      python \
+      tar \
+      which \
+      jq \
+      gcc \
+      awk \
+      grep \
+      openssl \
+      kubectl \
+      "
+    for package in $PACMANPACKAGES ; do
+      if ! pacman -Q $package 2> /dev/null ; then
+        echo "--> pacman installing $package"
+        ${sudo_command} pacman -Sy --noconfirm $package
+	fi
+    done
+    if ! command -v az >/dev/null 2>&1 ; then
+      echo "--> Attempting to install Azure-CLI with curl"
+      curl -L https://aka.ms/InstallAzureCli | sh
+    fi
+
 ## Mystery linux system without any of our recognised package managers
   else
     command -v curl >/dev/null 2>&1 || { echo >&2 "curl not found; please install and re-run this script."; exit 1; }
@@ -108,7 +134,7 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
     command -v jq >/dev/null 2>&1 || { echo >&2 "jq not found; please install and re-run this script."; exit 1; }
     echo "--> Attempting to install Azure-CLI with curl"
     if ! command -v az >/dev/null 2>&1 ; then
-      curl -L https://aka.ms/InstallAzureCli
+      curl -L https://aka.ms/InstallAzureCli | sh
     fi
     echo "--> Attempting to install kubectl with curl"
     if ! command -v kubectl >/dev/null 2>&1 ; then

--- a/setup.sh
+++ b/setup.sh
@@ -19,19 +19,19 @@ if [[ ${OSTYPE} == 'linux'* ]] ; then
     for package in $APTPACKAGES ; do
       if ! dpkg -s $package > /dev/null ; then
         echo "--> Apt installing $package"
-        ${sudo_command} apt update && ${sudo_command} apt install -y $package
+        ${sudo_command} apt update && ${sudo_command} apt install -y $package || { echo >&2 "--> $package install failed; please install manually and re-run this script."; exit 1; }
 	fi
     done
     if ! command -v az >/dev/null 2>&1 ; then
       echo "--> Attempting to install Azure-CLI with deb packages"
-      curl -sL https://aka.ms/InstallAzureCLIDeb | ${sudo_command} bash
+      curl -sL https://aka.ms/InstallAzureCLIDeb | ${sudo_command} bash || { echo >&2 "--> Azure-CLI install failed; please install manually and re-run this script."; exit 1; }
     fi
     if ! command -v kubectl >/dev/null 2>&1 ; then
       echo "--> Attempting to install kubectl with deb packages"
       ${sudo_command} apt-get update && ${sudo_command} apt-get install -y apt-transport-https
       curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | ${sudo_command} apt-key add -
       echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | ${sudo_command} tee -a /etc/apt/sources.list.d/kubernetes.list
-      ${sudo_command} apt-get update && ${sudo_command} apt-get install -y kubectl
+      ${sudo_command} apt-get update && ${sudo_command} apt-get install -y kubectl || { echo >&2 "--> kubectl install failed; please install manually and re-run this script."; exit 1; }
     fi
 
 ## yum-based systems
@@ -48,14 +48,14 @@ if [[ ${OSTYPE} == 'linux'* ]] ; then
     for package in $YUMPACKAGES ; do
       if ! rpm -q $package > /dev/null ; then
         echo "--> Yum installing $package"
-        ${sudo_command} yum install -y $package
-	fi
+        ${sudo_command} yum install -y $package || { echo >&2 "--> $package install failed; please install manually and re-run this script."; exit 1; }
+      fi
     done
     if ! command -v az >/dev/null 2>&1 ; then
       echo "--> Attempting to install Azure-CLI with yum packages"
       ${sudo_command} rpm --import https://packages.microsoft.com/keys/microsoft.asc
       ${sudo_command} sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
-      ${sudo_command} yum install -y azure-cli
+      ${sudo_command} yum install -y azure-cli || { echo >&2 "--> Azure-CLI install failed; please install manually and re-run this script."; exit 1; }
     fi
     if ! command -v kubectl >/dev/null 2>&1 ; then
       echo "--> Attempting to install kubectl with yum packages"
@@ -67,7 +67,7 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 " | ${sudo_command} tee /etc/yum.repos.d/kubernetes.repo
-      ${sudo_command} yum install -y kubectl
+      ${sudo_command} yum install -y kubectl || { echo >&2 "--> kubectl install failed; please install manually and re-run this script."; exit 1; }
     fi
 
 ## zypper-based systems
@@ -84,21 +84,21 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
     for package in $ZYPPERPACKAGES ; do
       if ! rpm -q $package > /dev/null ; then
         echo "--> Zypper installing $package"
-        ${sudo_command} zypper install -y $package
+        ${sudo_command} zypper install -y $package || { echo >&2 "--> $package install failed; please install manually and re-run this script."; exit 1; }
 	fi
     done
     if ! command -v az >/dev/null 2>&1 ; then
       echo "--> Attempting to install Azure-CLI with zypper packages"
       ${sudo_command} rpm --import https://packages.microsoft.com/keys/microsoft.asc
       ${sudo_command} zypper addrepo --name 'Azure CLI' --check https://packages.microsoft.com/yumrepos/azure-cli azure-cli
-      ${sudo_command} zypper install --from azure-cli -y azure-cli
+      ${sudo_command} zypper install --from azure-cli -y azure-cli || { echo >&2 "--> azure-cli install failed; please install manually and re-run this script."; exit 1; }
       # The az-cli installer misses python-xml dependency on suse
-      ${sudo_command} zypper install -y python-xml
+      ${sudo_command} zypper install -y python-xml || { echo >&2 "--> python-xml install failed; please install manually and re-run this script."; exit 1; }
     fi
     if ! command -v kubectl >/dev/null 2>&1 ; then
       echo "--> Attempting to install kubectl with zypper packages"
       zypper ar -f https://download.opensuse.org/tumbleweed/repo/oss/ factory
-      zypper install -y kubectl
+      zypper install -y kubectl || { echo >&2 "--> kubectl install failed; please install manually and re-run this script."; exit 1; }
     fi
 
 ## pacman-based systems
@@ -119,13 +119,13 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
     for package in $PACMANPACKAGES ; do
       if ! pacman -Q $package 2> /dev/null ; then
         echo "--> pacman installing $package"
-        ${sudo_command} pacman -Sy --noconfirm $package
+        ${sudo_command} pacman -Sy --noconfirm $package || { echo >&2 "--> $package install failed; please install manually and re-run this script."; exit 1; }
 	fi
     done
     if ! command -v az >/dev/null 2>&1 ; then
       echo "--> Attempting to install Azure-CLI with curl"
-      curl -L https://aka.ms/InstallAzureCli | sh
-    fi
+      curl -L https://aka.ms/InstallAzureCli | sh || { echo >&2 "--> Azure-CLI install failed; please install manually and re-run this script."; exit 1; }
+    fi 
 
 ## Mystery linux system without any of our recognised package managers
   else
@@ -134,11 +134,11 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
     command -v jq >/dev/null 2>&1 || { echo >&2 "jq not found; please install and re-run this script."; exit 1; }
     echo "--> Attempting to install Azure-CLI with curl"
     if ! command -v az >/dev/null 2>&1 ; then
-      curl -L https://aka.ms/InstallAzureCli | sh
+      curl -L https://aka.ms/InstallAzureCli | sh || { echo >&2 "--> Azure-CLI install failed; please install manually and re-run this script."; exit 1; }
     fi
     echo "--> Attempting to install kubectl with curl"
     if ! command -v kubectl >/dev/null 2>&1 ; then
-      curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+      curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl || { echo >&2 "--> kubectl download failed; please install manually and re-run this script."; exit 1; }
       chmod +x ./kubectl
       ${sudo_command} mv ./kubectl /usr/local/bin/kubectl
     fi
@@ -153,7 +153,7 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cl
     echo "--> Helm doesn't have a system package; attempting to install with curl"
     curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > get_helm.sh
     chmod 700 get_helm.sh
-    ./get_helm.sh
+    ./get_helm.sh || { echo >&2 "--> helm install failed; please install manually and re-run this script."; exit 1; }
   fi
 
 ## Installing on OS X
@@ -171,7 +171,7 @@ elif [[ ${OSTYPE} == 'darwin'* ]] ; then
     for package in $BREWPACKAGES ; do
       if ! brew ls --versions $package > /dev/null ; then
         echo "--> Brew installing $package"
-        brew update && brew install $package
+        brew update && brew install $package || { echo >&2 "--> $package install failed; please install manually and re-run this script."; exit 1; }
 	fi
     done
   else
@@ -181,11 +181,11 @@ elif [[ ${OSTYPE} == 'darwin'* ]] ; then
     command -v which >/dev/null 2>&1 || { echo >&2 "which not found; please install and re-run this script."; exit 1; }
     echo "--> Attempting to install Azure-CLI with curl"
     if ! command -v az >/dev/null 2>&1  ; then
-      curl -L https://aka.ms/InstallAzureCli
+      curl -L https://aka.ms/InstallAzureCli | sh || { echo >&2 "--> Azure-CLI install failed; please install manually and re-run this script."; exit 1; }
     fi
     echo "--> Attempting to install kubectl with curl"
     if ! command -v kubectl >/dev/null 2>&1 ; then
-      curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl
+      curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl || { echo >&2 "--> kubectl download failed; please install manually and re-run this script."; exit 1; }
       chmod +x ./kubectl
       ${sudo_command} mv ./kubectl /usr/local/bin/kubectl
     fi
@@ -193,7 +193,7 @@ elif [[ ${OSTYPE} == 'darwin'* ]] ; then
     if ! command -v helm >/dev/null 2>&1 ; then
       curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > get_helm.sh
       chmod 700 get_helm.sh
-      ./get_helm.sh
+      ./get_helm.sh || { echo >&2 "--> helm install failed; please install manually and re-run this script."; exit 1; }
     fi
   fi
 fi


### PR DESCRIPTION
Removes dependency on Python3 for CLI installation, some general bugfixes, and adds a boilerplate warning for silent failure of `jq` on CentOS distributions.