### PR TITLE
Allow unbound variables in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -264,7 +264,7 @@ while ! helm version ; do
   sleep 30
 done
 # Revert to error-intolerance
-set -eo pipefail
+set -euo pipefail
 
 # Create tokens for the secrets file:
 apiToken=`openssl rand -hex 32`

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Exit immediately if a pipeline returns a non-zero status
-set -euo pipefail
+set -eo pipefail
 
 # Get this script's path
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -262,7 +262,7 @@ while ! helm version ; do
   sleep 30
 done
 # Revert to error-intolerance
-set -euo pipefail
+set -eo pipefail
 
 # Create tokens for the secrets file:
 apiToken=`openssl rand -hex 32`

--- a/deploy.sh
+++ b/deploy.sh
@@ -160,6 +160,8 @@ else
   fi
 fi
 
+set -euo pipefail
+
 # Generate a valid name for the AKS cluster
 AKS_NAME=`echo ${BINDERHUB_NAME} | tr -cd '[:alnum:]-' | cut -c 1-59`-AKS
 


### PR DESCRIPTION
This PR allows unbound variables in `deploy.sh` so that the script can be run locally. At the moment, it exits due to `$BINDERHUB_CONTAINER_MODE` not being set.