### PR TITLE
Fix logs script to find hub pod name

### DIFF
--- a/logs.sh
+++ b/logs.sh
@@ -16,7 +16,7 @@ az aks get-credentials -n $AKS_NAME -g $AKS_RESOURCE_GROUP
 echo "--> Fetching JupyterHub logs"
 
 # Get pod name of the JupyterHub
-HUB_POD=`kubectl get pods -n hub23 -o=jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep "^hub-"`
+HUB_POD=`kubectl get pods -n ${BINDERHUB_NAME} -o=jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep "^hub-"`
 
 # Print the JupyterHub logs to the terminal
 kubectl logs ${HUB_POD} -n ${BINDERHUB_NAME}

--- a/logs.sh
+++ b/logs.sh
@@ -16,9 +16,7 @@ az aks get-credentials -n $AKS_NAME -g $AKS_RESOURCE_GROUP
 echo "--> Fetching JupyterHub logs"
 
 # Get pod name of the JupyterHub
-OUTPUT=`kubectl -n ${BINDERHUB_NAME} get pod | awk '{ print $1}' | tail -n 2`
-OUTPUT=($OUTPUT)
-HUB_POD=${OUTPUT[0]}
+HUB_POD=`kubectl get pods -n hub23 -o=jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep "^hub-"`
 
 # Print the JupyterHub logs to the terminal
 kubectl logs ${HUB_POD} -n ${BINDERHUB_NAME}


### PR DESCRIPTION
Logs script was dependent on the position of the hub pod in the output of `kubectl get pods`. Fix this to use grep to always find the hub pod, no matter how many pods are running.

fixes #61 

cc @trallard or @tmbgreaves for a review 🙂 