### PR TITLE
Add LOG_TO_BLOB_STORAGE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Fill the quotation marks with your desired namespaces, etc.
     "sp_app_id": null,             // Azure service principal ID (optional)
     "sp_app_key": null,            // Azure service principal password (optional)
     "sp_tenant_id": null,          // Azure tenant ID (optional)
-    "log_to_blob_storage": false   // Store logs in blobl storage when not running from a container
+    "log_to_blob_storage": false   // Store logs in blob storage when not running from a container
   },
   "binderhub": {
     "name": "",                    // Name of your BinderHub

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Fill the quotation marks with your desired namespaces, etc.
     "vm_size": "Standard_D2s_v3",  // Azure virtual machine type to deploy
     "sp_app_id": null,             // Azure service principal ID (optional)
     "sp_app_key": null,            // Azure service principal password (optional)
-    "sp_tenant_id": null           // Azure tenant ID (optional)
+    "sp_tenant_id": null,          // Azure tenant ID (optional)
+    "log_to_blob_storage": false   // Store logs in blobl storage when not running from a container
   },
   "binderhub": {
     "name": "",                    // Name of your BinderHub
@@ -167,6 +168,8 @@ Both a JupyterHub and BinderHub are installed via a Helm Chart onto the deployed
 
 The script also outputs log files (`<file-name>.log`) for each stage of the deployment.
 These files are also git-ignored.
+
+If the `azure.log_to_blob_storage` value in `config.json` is set to `true` the script is running from the command line, then the log files will be stored in blob storage.
 
 ### `logs.sh`
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -562,7 +562,7 @@ do
     echo "Binder IP: ${BINDER_IP}" | tee binder-ip.log
 done
 
-if [[ -n $BINDERHUB_CONTAINER_MODE ]] || [[ "${LOG_TO_BLOB_STORAGE,,}" = 'true' ]] ; then
+if [[ -n $BINDERHUB_CONTAINER_MODE ]] || [[ "$LOG_TO_BLOB_STORAGE" == 'true' ]] ; then
   # Finally, save outputs to blob storage
   #
   # Create a storage account


### PR DESCRIPTION
Addresses #85:

- Adds `azure.log_to_blob_storage` to `config.json`; when running from the command line and it is set, it will store the logs in blob storage as if it was a containerized deployment
- Updates documentation
- Templates were not updated; the logs will be stored in blob storage anyway, so it defaults `LOG_TO_BLOB_STORAGE` to `true`, even though it is never used.

Note: I wasn't sure how to generate automated test cases; if I could be pointed in that direction, please let me know.