### PR TITLE
Install Helm 3 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ FROM mcr.microsoft.com/azure-cli:2.0.76
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
       chmod +x ./kubectl && \
       mv ./kubectl /usr/local/bin/kubectl && \
-      curl https://get.helm.sh/helm-v2.16.9-linux-amd64.tar.gz --output helm.tar.gz && \
-	tar -xf ./helm.tar.gz && \
-	mv ./linux-amd64/helm /usr/local/bin/helm
+      curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
+	chmod 700 get_helm.sh && \
+	./get_helm.sh
 
 ADD . /app
 RUN find /app -type f -name '*.sh' -exec chmod +x {} \;


### PR DESCRIPTION
### Summary
<!-- Describe the purpose of the PR.
Is it fixing a bug or adding a feature? -->

related to #128 

### What's changed?
<!-- In the section, describe in more detail what this PR will change.
We recommend using bullet points. -->

- Helm3 is now installed in the Dockerfile by default

### What should a reviewer concentrate their feedback on?
<!-- You can request specific feedback in this section.
We recommend using check boxes. -->

- [x] Everything looks ok?

### Notes

- I've checked that helm has been installed into the container locally by running a bash entrypoint and executing the `(command -v helm3 || command -v helm)` command which threw the error reported in the original issue
