### PR TITLE
⚡️ Use regex to strip v from semver for docker tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
 
           if [ ${{ github.event_name }} = 'pull_request' ]; then
-            echo "tag=test-$(openssl rand -hex 2)" >> $GITHUB_ENV
+            echo "tag=test-${{ github.head_ref }}-$(openssl rand -hex 2)" >> $GITHUB_ENV
           else
 
             GIT_REF=$(echo ${{ github.ref }} | awk -F'/' '{print $3}')

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,8 +33,9 @@ jobs:
 
             if [ $GIT_REF = 'main' ]; then
               echo "tag=latest" >> $GITHUB_ENV
-            elif [[ $GIT_REF =~ v[0-9].[0-9].[0-9] ]]; then
-              echo "tag=$GIT_REF" >> $GITHUB_ENV
+            elif [[ $GIT_REF =~ (?<=v)[0-9]*\.[0-9]*\.[0-9]* ]]; then
+              NEW_REF=$(echo $GIT_REF | sed 's/v//')
+              echo "tag=$NEW_REF" >> $GITHUB_ENV
             fi
 
           fi


### PR DESCRIPTION
### Summary
<!-- Describe the purpose of the PR.
Is it fixing a bug or adding a feature? -->

This PR tweaks the Docker Build and Push CI workflow.

- When generating a Docker image tag from a git tag reference, the `v` from the sem-ver `vX.Y.Z` is stripped
- The branch of the PR is added to the image tag generated for build tests in PRs

