### PR TITLE
Add six requirement for docker_pull.py

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,3 @@
 docker
 requests
+six


### PR DESCRIPTION
fix broken CI https://github.com/alan-turing-institute/binderhub-deploy/runs/2957736785?check_suite_focus=true