### PR TITLE
Tweak the inputs to Docker metadata further

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,8 +24,11 @@ jobs:
         uses: docker/metadata-action@v3.6.2
         with:
           images: sgibson91/binderhub-setup
+          tags: |
+            type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
           flavor: |
-            latest=auto
+            latest=false
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,9 +14,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  DOCKERHUB_USERNAME: "sgibson91"
-
 jobs:
   docker-build:
     runs-on: ubuntu-latest
@@ -27,12 +24,14 @@ jobs:
         uses: docker/metadata-action@v3.6.2
         with:
           images: sgibson91/binderhub-setup
+          flavor: |
+            latest=auto
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: sgibson91
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,6 +27,7 @@ jobs:
           tags: |
             type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=ref,event=pr
           flavor: |
             latest=false
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,6 +28,7 @@ jobs:
             type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
             type=ref,event=pr
+            type=semver,pattern={{raw}}
           flavor: |
             latest=false
 


### PR DESCRIPTION
Ensure that the latest commit on `main` is built and pushed to the `latest` tag on Docker Hub. See https://github.com/docker/metadata-action/issues/147#issuecomment-971464075